### PR TITLE
Feature/gitlab ci integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+docker-compose.*
+.gitlab-ci.yml
+.env
+.env.example
+dev.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ docker-compose.*
 .env
 .env.example
 dev.sh
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 /node_modules
 /public/storage
 /vendor

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,15 +1,149 @@
-test:app:
-    script:
-        - docker-compose -f $COMPOSE_FILENAME pull
-        - docker-compose -f $COMPOSE_FILENAME build
-        - docker-compose -f $COMPOSE_FILENAME run api bash -c "composer install && php ./vendor/bin/phpunit"
-    cache:
-        untracked: true
-        paths:
-            - vendor/
-deploy:forge:
+variables:
+    PROJECT_NAME: vanilla
+    PHP_IMAGE: $CI_REGISTRY_IMAGE:php-$CI_BUILD_REF_NAME
+    PHP_STABLE_IMAGE: $CI_REGISTRY_IMAGE:php-$CI_BUILD_TAG
+    WWW_IMAGE: $CI_REGISTRY_IMAGE:www-$CI_BUILD_REF_NAME
+    WWW_STABLE_IMAGE: $CI_REGISTRY_IMAGE:www-$CI_BUILD_TAG
+    VIRTUAL_HOST: $APP_ENV.$PROJECT_NAME.staging.desmart.com
+    COMPOSE_FILE: docker-compose.staging.yml
+
+before_script:
+    - &COMPOSE_PROJECT_NAME export COMPOSE_PROJECT_NAME=$(echo "${CI_PROJECT_PATH}/${CI_BUILD_REF_NAME}" | sed -e 's/\(release\)\/.*$/\1/' | tr -cd '[[:alnum:]]' | tr '[:upper:]' '[:lower:]')
+    - test -x docker && docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN $CI_REGISTRY
+
+stages:
+    - test
+    - build
+    - deploy
+
+# templates
+.test: &TEST_ENV
     stage: deploy
     only:
         - develop
+    environment:
+        name: test
+    tags:
+        - deploy
+    variables:
+        APP_ENV: test
+        APP_DEBUG: "true"
+
+.beta: &BETA_ENV
+    stage: deploy
+    only:
+        - /^release/
+    environment:
+        name: beta
+    tags:
+        - deploy
+    variables:
+        CI_BUILD_REF_NAME: release
+        APP_ENV: beta
+        APP_DEBUG: "false"
+
+.scripts:
+    install compose: &INSTALL_DOCKER_COMPOSE
+        - apk add --update py-pip
+        - pip install docker-compose
+    deploy: &DEPLOY_SCRIPTS
+        - *COMPOSE_PROJECT_NAME
+        - docker-compose pull
+        - docker-compose up -d
+        - sleep 20
+        - docker-compose run php php artisan migrate
+    stop: &STOP_SCRIPTS
+        - *COMPOSE_PROJECT_NAME
+        - docker-compose stop
+        - docker-compose rm --force
+    seed: &SEED_SCRIPTS
+        - *COMPOSE_PROJECT_NAME
+        - docker-compose run php php artisan migrate:refresh --seed
+# templates - end
+
+test:app:
+    stage: test
     script:
-        - wget <DEPLOY_SCRIPT_URL> -O /dev/null
+        - export COMPOSE_FILE=docker-compose.local.yml
+        - docker-compose pull
+        - docker-compose build
+        - docker-compose run -e APP_KEY=$APP_KEY php make test
+
+build:images: &BUILD_IMAGES
+    stage: build
+    script:
+        - docker-compose -f docker-compose.base.yml build
+        - docker images
+        - docker tag ${COMPOSE_PROJECT_NAME}_www $WWW_IMAGE
+        - docker push $WWW_IMAGE
+        - docker tag ${COMPOSE_PROJECT_NAME}_php $PHP_IMAGE
+        - docker push $PHP_IMAGE
+    only:
+        - master
+        - develop
+
+build:images:release:
+    <<: *BUILD_IMAGES
+    variables:
+        CI_BUILD_REF_NAME: release
+    only:
+        - /^release/
+
+test:deploy:
+    <<: *TEST_ENV
+    script: *INSTALL_DOCKER_COMPOSE
+    after_script: *DEPLOY_SCRIPTS
+    environment:
+        name: test
+        on_stop: "test:stop"
+
+test:stop:
+    <<: *TEST_ENV
+    script: *INSTALL_DOCKER_COMPOSE
+    after_script: *STOP_SCRIPTS
+    when: manual
+    environment:
+        name: test
+        action: stop
+
+test:db:seed:
+    <<: *TEST_ENV
+    script: *INSTALL_DOCKER_COMPOSE
+    after_script: *SEED_SCRIPTS
+    when: manual
+
+beta:deploy:
+    <<: *BETA_ENV
+    script: *INSTALL_DOCKER_COMPOSE
+    after_script: *DEPLOY_SCRIPTS
+    environment:
+        name: beta
+        on_stop: "beta:stop"
+
+beta:stop:
+    <<: *BETA_ENV
+    script: *INSTALL_DOCKER_COMPOSE
+    after_script: *STOP_SCRIPTS
+    when: manual
+    environment:
+        name: beta
+        action: stop
+
+beta:db:seed:
+    <<: *BETA_ENV
+    script: *INSTALL_DOCKER_COMPOSE
+    after_script: *SEED_SCRIPTS
+    when: manual
+
+deploy:production:images:
+    stage: deploy
+    only:
+        - master
+    script:
+        - test -z "$CI_BUILD_TAG" && exit 0
+        - docker pull $PHP_IMAGE
+        - docker tag $PHP_IMAGE $PHP_STABLE_IMAGE
+        - docker push $PHP_STABLE_IMAGE
+        - docker pull $WWW_IMAGE
+        - docker tag $WWW_IMAGE $WWW_STABLE_IMAGE
+        - docker push $WWW_STABLE_IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,11 +67,16 @@ stages:
 
 test:app:
     stage: test
+    variables:
+        COMPOSE_FILE: docker-compose.local.yml
     script:
-        - export COMPOSE_FILE=docker-compose.local.yml
         - docker-compose pull
         - docker-compose build
         - docker-compose run -e APP_KEY=$APP_KEY php make test
+    after_script:
+        - *COMPOSE_PROJECT_NAME
+        - docker-compose stop
+        - docker-compose rm --force
 
 build:php:image: &BUILD_PHP_IMAGE
     stage: build
@@ -94,6 +99,7 @@ build:www:image: &BUILD_WWW_IMAGE
     only:
         - master
         - develop
+        - *TAG_PATTERN
 
 build:php:release:image:
     <<: *BUILD_PHP_IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,9 @@ stages:
         APP_ENV: beta
         APP_DEBUG: "false"
 
+.stable:
+    tag-pattern: &TAG_PATTERN /\d+\.\d+\.\d+/
+
 .scripts:
     install compose: &INSTALL_DOCKER_COMPOSE
         - apk add --update py-pip
@@ -79,6 +82,7 @@ build:php:image: &BUILD_PHP_IMAGE
     only:
         - master
         - develop
+        - *TAG_PATTERN
 
 build:www:image: &BUILD_WWW_IMAGE
     stage: build
@@ -151,10 +155,10 @@ beta:db:seed:
     after_script: *SEED_SCRIPTS
     when: manual
 
-deploy:production:images:
+tag:stable:images:
     stage: deploy
     only:
-        - master
+        - *TAG_PATTERN
     script:
         - test -z "$CI_BUILD_TAG" && exit 0
         - docker pull $PHP_IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
     WWW_STABLE_IMAGE: $CI_REGISTRY_IMAGE:www-$CI_BUILD_TAG
     VIRTUAL_HOST: $APP_ENV.$PROJECT_NAME.staging.desmart.com
     COMPOSE_FILE: docker-compose.staging.yml
+    NODE_VERSION: "7.1"
 
 before_script:
     - &COMPOSE_PROJECT_NAME export COMPOSE_PROJECT_NAME=$(echo "${CI_PROJECT_PATH}/${CI_BUILD_REF_NAME}" | sed -e 's/\(release\)\/.*$/\1/' | tr -cd '[[:alnum:]]' | tr '[:upper:]' '[:lower:]')
@@ -69,21 +70,36 @@ test:app:
         - docker-compose build
         - docker-compose run -e APP_KEY=$APP_KEY php make test
 
-build:images: &BUILD_IMAGES
+build:php:image: &BUILD_PHP_IMAGE
     stage: build
     script:
-        - docker-compose -f docker-compose.base.yml build
-        - docker images
-        - docker tag ${COMPOSE_PROJECT_NAME}_www $WWW_IMAGE
-        - docker push $WWW_IMAGE
+        - docker-compose -f docker-compose.base.yml build php
         - docker tag ${COMPOSE_PROJECT_NAME}_php $PHP_IMAGE
         - docker push $PHP_IMAGE
     only:
         - master
         - develop
 
-build:images:release:
-    <<: *BUILD_IMAGES
+build:www:image: &BUILD_WWW_IMAGE
+    stage: build
+    script:
+        - docker run --rm -v ${PWD}:/usr/src/app -w /usr/src/app node:$NODE_VERSION make assets
+        - docker-compose -f docker-compose.base.yml build www
+        - docker tag ${COMPOSE_PROJECT_NAME}_www $WWW_IMAGE
+        - docker push $WWW_IMAGE
+    only:
+        - master
+        - develop
+
+build:php:release:image:
+    <<: *BUILD_PHP_IMAGE
+    variables:
+        CI_BUILD_REF_NAME: release
+    only:
+        - /^release/
+
+build:www:release:image:
+    <<: *BUILD_WWW_IMAGE
     variables:
         CI_BUILD_REF_NAME: release
     only:

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,12 @@ dev-deps:
 
 test: dev-deps
 	php ./vendor/bin/phpunit
+
+npm-deps:
+	which yarn > /dev/null || npm i -g yarn
+	yarn
+
+assets: npm-deps
+	npm run prod
+
+# vim: set noexpandtab tabstop=4

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+dev-deps:
+	composer install --prefer-dist
+
+test: dev-deps
+	php ./vendor/bin/phpunit

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -1,12 +1,16 @@
-www:
-    build: ./docker/nginx/
-    dockerfile: Dockerfile
+version: '2'
+services:
+    www:
+        build:
+            context: .
+            dockerfile: docker/nginx/Dockerfile
 
-api:
-    build: .
-    dockerfile: docker/php7/Dockerfile
+    php:
+        build:
+            context: .
+            dockerfile: docker/php7/Dockerfile
 
-db:
-    image: mysql:5.7
-    environment:
-        - "MYSQL_ROOT_PASSWORD=123qwe"
+    db:
+        image: mysql:5.7
+        environment:
+            - "MYSQL_RANDOM_ROOT_PASSWORD=yes"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,28 +1,38 @@
-www:
-    extends:
-        file: docker-compose.base.yml
-        service: www
-    ports:
-        - "8080:80"
-    links:
-        - api
-    volumes:
-        - "./docker/nginx/vhost.conf:/etc/nginx/conf.d/default.conf"
-        - "./:/var/www/vanilla"
+version: '2'
+services:
+    www:
+        extends:
+            file: docker-compose.base.yml
+            service: www
+        ports:
+            - "8080:80"
+        volumes:
+            - "./docker/nginx/vhost.conf:/etc/nginx/conf.d/default.conf"
+            - "./:/usr/src/app"
 
-api:
-    extends:
-        file: docker-compose.base.yml
-        service: api
-    links:
-        - db
-    volumes:
-        - "./:/var/www/vanilla"
-    environment:
-        - "APP_ENV=local"
-        - "APP_DEBUG=true"
+    php:
+        extends:
+            file: docker-compose.base.yml
+            service: php
+        volumes:
+            - "./:/usr/src/app"
+        environment:
+            - "APP_ENV=local"
+            - "APP_DEBUG=true"
+            - "DB_HOST=db"
+            - "DB_DATABASE=vanilla_app"
+            - "DB_USERNAME=vanilla"
+            - "DB_PASSWORD=someRandomString"
 
-db:
-    extends:
-        file: docker-compose.base.yml
-        service: db
+    db:
+        extends:
+            file: docker-compose.base.yml
+            service: db
+        ports:
+            - "3306:3306"
+        environment:
+            - "MYSQL_RANDOM_ROOT_PASSWORD=no"
+            - "MYSQL_ROOT_PASSWORD=123qwe"
+            - "MYSQL_DATABASE=vanilla_app"
+            - "MYSQL_USER=vanilla"
+            - "MYSQL_PASSWORD=someRandomString"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,32 @@
+version: '2'
+services:
+    www:
+        image: $WWW_IMAGE
+        environment:
+            - "VIRTUAL_HOST"
+        networks:
+            - default
+            - service-proxy
+
+    php:
+        image: $PHP_IMAGE
+        environment:
+            - "APP_ENV"
+            - "APP_DEBUG"
+            - "DB_HOST=db"
+            - "DB_DATABASE=app"
+            - "DB_USERNAME=app_user"
+            - "DB_PASSWORD=someVeryRandomPassword"
+            - "APP_KEY"
+
+    db:
+        extends:
+            file: docker-compose.base.yml
+            service: db
+        environment:
+            - "MYSQL_DATABASE=app"
+            - "MYSQL_USER=app_user"
+            - "MYSQL_PASSWORD=someVeryRandomPassword"
+networks:
+    service-proxy:
+        external: true

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,5 +1,7 @@
-FROM nginx:1.9
+FROM nginx:1.11-alpine
 MAINTAINER desmart
 
-RUN rm /etc/nginx/conf.d/default.conf
-COPY vhost.conf /etc/nginx/conf.d/default.conf
+COPY docker/nginx/vhost.conf /etc/nginx/conf.d/default.conf
+
+RUN mkdir -p /usr/src/app/public
+COPY public /usr/src/app/public

--- a/docker/nginx/vhost.conf
+++ b/docker/nginx/vhost.conf
@@ -1,7 +1,7 @@
 server {
     listen 80;
 
-    root /var/www/vanilla/public;
+    root /usr/src/app/public;
 
     index index.html index.htm index.php;
 
@@ -21,7 +21,7 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass api:9000;
+        fastcgi_pass php:9000;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/docker/php7/Dockerfile
+++ b/docker/php7/Dockerfile
@@ -20,3 +20,5 @@ RUN chmod -R 777 storage
 RUN set -xeu \
     && php artisan optimize \
     && php artisan vendor:publish
+
+VOLUME /usr/src/app/public/upload

--- a/docker/php7/Dockerfile
+++ b/docker/php7/Dockerfile
@@ -1,24 +1,24 @@
-FROM php:7-fpm
-MAINTAINER desmart
+FROM desmart/php:7.0-fpm-alpine
 
-# Install composer
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php composer-setup.php \
-    && php -r "unlink('composer-setup.php');" \
-    && mv composer.phar /usr/local/bin/composer \
-    && echo 'deb http://packages.dotdeb.org jessie all' >> /etc/apt/sources.list \
-    && echo 'deb-src http://packages.dotdeb.org jessie all' >> /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get install -qq --yes wget \
-    && wget https://www.dotdeb.org/dotdeb.gpg \
-    && apt-key add dotdeb.gpg \
-    && apt-get update \
-    && apt-get install --yes git less php7.0-mysql \
-    && docker-php-ext-install pdo_mysql
+COPY ["composer.json", "composer.lock", "./"]
+COPY database/ database/
+COPY tests/ tests/
+COPY config/ config/
 
-COPY docker/php7/overrides.ini /usr/local/etc/php/conf.d/overrides.ini
-
-# Base directory for the app code
-WORKDIR /var/www/vanilla
+RUN set -xeu \
+    && composer install --no-dev --prefer-dist --no-interaction --no-progress --no-scripts \
+    && composer clear-cache
 
 COPY . ./
+
+RUN mkdir -p public/upload \
+    && chmod -R 777 public/upload
+
+RUN chmod -R 777 bootstrap/cache
+RUN chmod -R 777 storage
+
+RUN set -xeu \
+    && php artisan optimize \
+    && php artisan vendor:publish
+
+VOLUME /usr/src/app/public/upload

--- a/docker/php7/Dockerfile
+++ b/docker/php7/Dockerfile
@@ -20,5 +20,3 @@ RUN chmod -R 777 storage
 RUN set -xeu \
     && php artisan optimize \
     && php artisan vendor:publish
-
-VOLUME /usr/src/app/public/upload

--- a/readme.md
+++ b/readme.md
@@ -19,11 +19,32 @@ Proceed with the following commands:
 dc up -d
 chmod -R 0777 bootstrap/ storage/ (on host machine)
 cp .env.example .env
-dc run api composer install --prefer-source
+dc run api composer install --prefer-dist
 dc run api php artisan key:generate
 dc run api php vendor/bin/codecept bootstrap
 rm -rf .git
 ```
+
+### Setting up Gitlab CI
+
+1. Goto variables setting page (https://git.desmart.com/PROJECT/PATH/variables)
+2. Add entry for `APP_KEY` (it will be used for staging environments, and during test builds)
+   * this entry should contain full output of `artisan key:generate --show` command  
+     alternatively run this command - it will generate full key:
+
+   ```
+   docker run --rm desmart/laravel-appkey
+   ```
+
+CI, by default, will:
+
+* run unit tests on every push
+  * test command is defined in `Makefile`, it will be ran on `php` container 
+* generate and push to registry docker images for `php` and `www` service.
+  * images will be built for branches: `develop`, `master`, `release/*` and stable (tagged) versions
+* depending on branch a new staging version will be deployed:
+  * `develop` -> test version
+  * `release/*` -> beta version
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ rm -rf .git
    ```
    docker run --rm desmart/laravel-appkey
    ```
+3. Edit `.gitlab-ci.yml` file and update `variables.PROJECT_NAME` value to match yours project name
 
 CI, by default, will:
 
@@ -43,8 +44,8 @@ CI, by default, will:
 * generate and push to registry docker images for `php` and `www` service.
   * images will be built for branches: `develop`, `master`, `release/*` and stable (tagged) versions
 * depending on branch a new staging version will be deployed:
-  * `develop` -> test version
-  * `release/*` -> beta version
+  * `develop` -> test version (url: test.PROJECT_NAME.staging.desmart.com)
+  * `release/*` -> beta version (url: beta.PROJECT_NAME.staging.desmart.com)
 
 ### Suggested packages
 


### PR DESCRIPTION
## About this PR:

Full integration with Gitlab CI process and Docker images build/deployment

Changes contain updated `.gitlab-ci.yml` config with support of:
* test stage
* complete docker images build process (including pushing to private registry) - separated to two threads
* deploy jobs
* tagging stable images

Vanilla will use our base Docker PHP image (`desmart/php:7.0-fpm-alpine`).

### Environments:

![zrzut ekranu 2016-11-10 o 19 27 30](https://cloud.githubusercontent.com/assets/1190255/20189110/072740da-a77c-11e6-918b-ef2362175638.png)

Gitlab will support deploying two different environments:
* `test` on every change on `develop` branch
* `beta` on every change on `release/*` branch

URL to deployed version will be: `ENV.PROJECT_NAME.staging.desmart.com`

Each env is tagged and contains two jobs which can be run manualy: 
* db seed - will reset database, migrate it again and seed
* stop - remove given environment from our staging server

## Questions:

* ~build process for `master` and tagged (eg `1.0.0`) version is basically the same (test, build images) IMO we can run them only for tagged versions. What do you think about it?~

## TODO:

- [x] Gitlab integration docs